### PR TITLE
bug fixed in e031A

### DIFF
--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -1738,19 +1738,12 @@ def partitions(n, m=None, k=None, size=False):
     {2: 1, 4: 1}
     {3: 2}
 
-    Note that the _same_ dictionary object is returned each time.
-    This is for speed:  generating each partition goes quickly,
-    taking constant time, independent of n.
+    Each partition is returned as a new dictionary.
 
-    >>> [p for p in partitions(6, k=2)]
-    [{1: 6}, {1: 6}, {1: 6}, {1: 6}]
-
-    If you want to build a list of the returned dictionaries then
-    make a copy of them:
-
-    >>> [p.copy() for p in partitions(6, k=2)]  # doctest: +SKIP
+    >>> [p for p in partitions(6, k=2)]  # doctest: +SKIP
     [{2: 3}, {1: 2, 2: 2}, {1: 4, 2: 1}, {1: 6}]
-    >>> [(M, p.copy()) for M, p in partitions(6, k=2, size=True)]  # doctest: +SKIP
+
+    >>> [(M, p) for M, p in partitions(6, k=2, size=True)]  # doctest: +SKIP
     [(3, {2: 3}), (4, {1: 2, 2: 2}), (5, {1: 4, 2: 1}), (6, {1: 6})]
 
     References
@@ -1802,9 +1795,9 @@ def partitions(n, m=None, k=None, size=False):
         keys.append(r)
     room = m - q - bool(r)
     if size:
-        yield sum(ms.values()), ms
+        yield sum(ms.values()), ms.copy()
     else:
-        yield ms
+        yield ms.copy()
 
     while keys != [1]:
         # Reuse any 1's.
@@ -1842,9 +1835,9 @@ def partitions(n, m=None, k=None, size=False):
             break
         room -= need
         if size:
-            yield sum(ms.values()), ms
+            yield sum(ms.values()), ms.copy()
         else:
-            yield ms
+            yield ms.copy()
 
 
 def ordered_partitions(n, m=None, sort=True):

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -481,24 +481,24 @@ def test_partitions():
         assert list(partitions(6, None, 2, size=i)) != ans[i]
         assert list(partitions(6, 2, 0, size=i)) == ans[i]
 
-    assert [p.copy() for p in partitions(6, k=2)] == [
+    assert list(partitions(6, k=2)) == [
         {2: 3}, {1: 2, 2: 2}, {1: 4, 2: 1}, {1: 6}]
 
-    assert [p.copy() for p in partitions(6, k=3)] == [
+    assert list(partitions(6, k=3)) == [
         {3: 2}, {1: 1, 2: 1, 3: 1}, {1: 3, 3: 1}, {2: 3}, {1: 2, 2: 2},
         {1: 4, 2: 1}, {1: 6}]
 
-    assert [p.copy() for p in partitions(8, k=4, m=3)] == [
+    assert list(partitions(8, k=4, m=3)) == [
         {4: 2}, {1: 1, 3: 1, 4: 1}, {2: 2, 4: 1}, {2: 1, 3: 2}] == [
-        i.copy() for i in partitions(8, k=4, m=3) if all(k <= 4 for k in i)
-        and sum(i.values()) <=3]
+        i for i in partitions(8, k=4, m=3) if all(k <= 4 for k in i)
+        and sum(i.values()) <= 3]
 
-    assert [p.copy() for p in partitions(S(3), m=2)] == [
+    assert list(partitions(S(3), m=2)) == [
         {3: 1}, {1: 1, 2: 1}]
 
-    assert [i.copy() for i in partitions(4, k=3)] == [
+    assert list(partitions(4, k=3)) == [
         {1: 1, 3: 1}, {2: 2}, {1: 2, 2: 1}, {1: 4}] == [
-        i.copy() for i in partitions(4) if all(k <= 3 for k in i)]
+        i for i in partitions(4) if all(k <= 3 for k in i)]
 
 
     # Consistency check on output of _partitions and RGS_unrank.
@@ -697,7 +697,7 @@ def test_reshape():
 
 
 def test_uniq():
-    assert list(uniq(p.copy() for p in partitions(4))) == \
+    assert list(uniq(partitions(4))) == \
         [{4: 1}, {1: 1, 3: 1}, {2: 2}, {1: 2, 2: 1}, {1: 4}]
     assert list(uniq(x % 2 for x in range(5))) == [0, 1]
     assert list(uniq('a')) == ['a']

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -315,7 +315,7 @@ def test_F5():
 
 
 def test_F6():
-    partTest = [p.copy() for p in partitions(4)]
+    partTest = list(partitions(4))
     partDesired = [{4: 1}, {1: 1, 3: 1}, {2: 2}, {1: 2, 2:1}, {1: 4}]
     assert partTest == partDesired
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
