### PR TITLE
bug fixed in e27-2b

### DIFF
--- a/sympy/geometry/point.py
+++ b/sympy/geometry/point.py
@@ -105,6 +105,8 @@ class Point(GeometryEntity):
 
     is_Point = True
 
+    _op_priority = 11.0
+
     def __new__(cls, *args, **kwargs):
         evaluate = kwargs.get('evaluate', global_evaluate[0])
         on_morph = kwargs.get('on_morph', 'ignore')
@@ -277,6 +279,9 @@ class Point(GeometryEntity):
         factor = sympify(factor)
         coords = [simplify(x*factor) for x in self.args]
         return Point(coords, evaluate=False)
+
+    def __rmul__(self, factor):
+        return self*factor
 
     def __neg__(self):
         """Negate the point."""

--- a/sympy/geometry/point.py
+++ b/sympy/geometry/point.py
@@ -280,8 +280,12 @@ class Point(GeometryEntity):
         coords = [simplify(x*factor) for x in self.args]
         return Point(coords, evaluate=False)
 
+<<<<<<< ours
     def __rmul__(self, factor):
         return self*factor
+=======
+    __rmul__ = __mul__
+>>>>>>> theirs
 
     def __neg__(self):
         """Negate the point."""

--- a/sympy/geometry/tests/test_point.py
+++ b/sympy/geometry/tests/test_point.py
@@ -27,6 +27,8 @@ def test_point():
     assert (p3 + p4) == p4
     assert (p2 - p1) == Point(y1 - x1, y2 - x2)
     assert p4*5 == Point(5, 5)
+    assert S(2.0)*p4 == Point(2.0, 2.0)
+    assert p3 + S(2.0)*p4 == Point(2.0, 2.0)
     assert -p2 == Point(-y1, -y2)
     raises(ValueError, lambda: Point(3, I))
     raises(ValueError, lambda: Point(2*I, I))

--- a/sympy/geometry/tests/test_point.py
+++ b/sympy/geometry/tests/test_point.py
@@ -354,6 +354,12 @@ def test_arguments():
     assert a/10.0 == Point(0, 0.1, evaluate=False)
     a = Point(0, 1)
     assert a*10.0 == Point(0.0, 10.0, evaluate=False)
+    # reversed multiplication should behave the same
+    assert 10.0*a == a*10.0
+    # test addition with reversed multiplication yields same result as forward multiplication
+    p1 = Point(0, 0)
+    p2 = Point(1, 1)
+    assert p1 + p2*2.0 == p1 + 2.0*p2
 
     # test evaluate=False when changing dimensions
     u = Point(.1, .2, evaluate=False)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
