### PR TITLE
bug fixed in F37Main

### DIFF
--- a/sympy/core/_print_helpers.py
+++ b/sympy/core/_print_helpers.py
@@ -17,6 +17,8 @@ class Printable:
     This also adds support for LaTeX printing in jupyter notebooks.
     """
 
+    __slots__ = ()
+
     # Note, we always use the default ordering (lex) in __str__ and __repr__,
     # regardless of the global setting. See issue 5487.
     def __str__(self):

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -5,6 +5,11 @@ from sympy.core.symbol import uniquely_named_symbol, _symbol, Str
 from sympy.testing.pytest import raises
 from sympy.core.symbol import disambiguate
 
+
+def test_symbol_no_dict():
+    s = Symbol('s')
+    assert not hasattr(s, '__dict__')
+
 def test_Str():
     a1 = Str('a')
     a2 = Str('a')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
