### PR TITLE
bug fixed in F40-1A

### DIFF
--- a/sympy/core/mod.py
+++ b/sympy/core/mod.py
@@ -118,7 +118,18 @@ class Mod(Function):
                 return cls(net, q)
 
         elif isinstance(p, Mul):
-            # separating into modulus and non modulus
+            if q.is_Integer:
+                c, rest = p.as_coeff_Mul()
+                if c.is_Integer:
+                    c1 = c % q
+                    if c1 == 0:
+                        return S.Zero
+                    if c1 != c:
+                        if rest is S.One:
+                            p = c1
+                        else:
+                            p = c1*rest
+                        return cls(p, q)
             both_l = non_mod_l, mod_l = [], []
             for arg in p.args:
                 both_l[isinstance(arg, cls)].append(arg)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1624,6 +1624,7 @@ def test_Mod():
     i = Symbol('i', integer=True)
     assert (3*i*x) % (2*i*y) == i*Mod(3*x, 2*y)
     assert Mod(4*i, 4) == 0
+    assert Mod(3*i, 2) == Mod(i, 2)
 
     # issue 8677
     n = Symbol('n', integer=True, positive=True)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
