### PR TITLE
bug fixed in F43-1A

### DIFF
--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -331,6 +331,13 @@ class MpmathPrinter(PythonCodePrinter):
         args = str(tuple(map(int, e._mpf_)))
         return '{func}({args})'.format(func=self._module_format('mpmath.mpf'), args=args)
 
+    def _print_Rational(self, expr):
+        mpf = self._module_format('mpmath.mpf')
+        p, q = expr.p, expr.q
+        if q == 1:
+            return '{0}({1})'.format(mpf, p)
+        return '({0}({1})/{0}({2}))'.format(mpf, p, q)
+
 
     def _print_uppergamma(self, e):
         return "{0}({1}, {2}, {3})".format(

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function)
 
 from sympy.codegen import Assignment
-from sympy.core import Expr, Mod, symbols, Eq, Le, Gt, zoo, oo
+from sympy.core import Expr, Mod, symbols, Eq, Le, Gt, zoo, oo, Rational
 from sympy.core.numbers import pi
 from sympy.codegen.ast import none
 from sympy.external import import_module
@@ -40,6 +40,7 @@ def test_PythonCodePrinter():
 def test_MpmathPrinter():
     p = MpmathPrinter()
     assert p.doprint(sign(x)) == 'mpmath.sign(x)'
+    assert p.doprint(Rational(1, 3)) == '(mpmath.mpf(1)/mpmath.mpf(3))'
 
 
 def test_NumPyPrinter():

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -157,6 +157,13 @@ def test_mpmath_precision():
     mpmath.mp.dps = 100
     assert str(lambdify((), pi.evalf(100), 'mpmath')()) == str(pi.evalf(100))
 
+@conserve_mpmath_dps
+def test_mpmath_rational_precision():
+    mpmath.mp.dps = 80
+    f = lambdify((), Rational(232, 3), 'mpmath')
+    ref = mpmath.mpf(232) / 3
+    assert abs(f() - ref) < mpmath.mpf('1e-79')
+
 #================== Test Translations ==============================
 # We can only check if all translated functions are valid. It has to be checked
 # by hand if they are complete.


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
