### PR TITLE
bug fixed in F47-1A

### DIFF
--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -6,7 +6,7 @@ This module contains python code printers for plain python as well as NumPy & Sc
 from collections import defaultdict
 from itertools import chain
 from sympy.core import S
-from .precedence import precedence
+from .precedence import precedence, PRECEDENCE
 from .codeprinter import CodePrinter
 
 _kw_py2and3 = {
@@ -233,8 +233,11 @@ class AbstractPythonCodePrinter(CodePrinter):
         return self._print_NaN(expr)
 
     def _print_Mod(self, expr):
-        PREC = precedence(expr)
-        return ('{} % {}'.format(*map(lambda x: self.parenthesize(x, PREC), expr.args)))
+        PREC = PRECEDENCE["Mul"]
+        a, b = expr.args
+        return '({} % {})'.format(
+            self.parenthesize(a, PREC),
+            self.parenthesize(b, PREC))
 
     def _print_Piecewise(self, expr):
         result = []

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -29,7 +29,7 @@ def test_PythonCodePrinter():
     assert not prntr.module_imports
 
     assert prntr.doprint(x**y) == 'x**y'
-    assert prntr.doprint(Mod(x, 2)) == 'x % 2'
+    assert prntr.doprint(Mod(x, 2)) == '(x % 2)'
     assert prntr.doprint(And(x, y)) == 'x and y'
     assert prntr.doprint(Or(x, y)) == 'x or y'
     assert not prntr.module_imports
@@ -221,7 +221,7 @@ def test_frac():
     assert prntr.doprint(expr) == 'numpy.mod(x, 1)'
 
     prntr = PythonCodePrinter()
-    assert prntr.doprint(expr) == 'x % 1'
+    assert prntr.doprint(expr) == '(x % 1)'
 
     prntr = MpmathPrinter()
     assert prntr.doprint(expr) == 'mpmath.frac(x)'

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -7,7 +7,7 @@ from sympy.testing.pytest import raises
 from sympy import (
     symbols, lambdify, sqrt, sin, cos, tan, pi, acos, acosh, Rational,
     Float, Lambda, Piecewise, exp, E, Integral, oo, I, Abs, Function,
-    true, false, And, Or, Not, ITE, Min, Max, floor, diff, IndexedBase, Sum,
+    true, false, And, Or, Not, ITE, Min, Max, Mod, floor, diff, IndexedBase, Sum,
     DotProduct, Eq, Dummy, sinc, erf, erfc, factorial, gamma, loggamma,
     digamma, RisingFactorial, besselj, bessely, besseli, besselk, S, beta,
     betainc, betainc_regularized, fresnelc, fresnels)
@@ -1273,6 +1273,13 @@ def test_issue_13167_21411():
 def test_single_e():
     f = lambdify(x, E)
     assert f(23) == exp(1.0)
+
+
+def test_Mod_modules_empty():
+    f = lambdify((x, y), -Mod(x, y), modules=[])
+    assert f(3, 7) == -3
+    g = lambdify((x, y), 2*Mod(x, y), modules=[])
+    assert g(5, 7) == 10
 
 def test_issue_16536():
     if not scipy:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
