### PR TITLE
bug fixed in F47--1B

### DIFF
--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -496,6 +496,16 @@ class CodePrinter(StrPrinter):
                 b_str[b.index(item.base)] = "(%s)" % b_str[b.index(item.base)]
 
         if not b:
+            # Special case: if the result is a single factor with a leading
+            # negative sign and that factor prints using an operator with the
+            # same precedence as multiplication (e.g. Mod printed as `%`),
+            # Python would evaluate "-factor" by applying the unary minus to
+            # the left operand of that operator. To preserve SymPy semantics
+            # we need parentheses, e.g. "-(a % b)" instead of "-a % b".
+            if sign and len(a) == 1:
+                from sympy.core.mod import Mod as SympyMod
+                if isinstance(a[0], SympyMod):
+                    return sign + "(" + a_str[0] + ")"
             return sign + '*'.join(a_str)
         elif len(b) == 1:
             return sign + '*'.join(a_str) + "/" + b_str[0]

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -232,6 +232,36 @@ class AbstractPythonCodePrinter(CodePrinter):
     def _print_ComplexInfinity(self, expr):
         return self._print_NaN(expr)
 
+    def parenthesize(self, item, level, strict=False):
+        """
+        Override StrPrinter.parenthesize to account for Python operator
+        precedence differences when SymPy expressions are printed using
+        Python operators.
+
+        In particular, SymPy's Mod is a Function but is printed using the
+        Python `%` operator. In Python, `%` has the same precedence as `*`.
+        Without special handling, Mod would be treated as having function
+        precedence which is higher than multiplication, causing expressions
+        like `expr*Mod(a, b)` to be printed as `expr*a % b`, which Python
+        evaluates as `(expr*a) % b`. We want `expr*(a % b)` instead.
+
+        By treating Mod as having multiplication precedence for the purposes
+        of parenthesization we ensure the generated Python code preserves the
+        intended evaluation order.
+        """
+        from sympy.core.mod import Mod as SympyMod
+        from sympy.printing.precedence import PRECEDENCE
+
+        if isinstance(item, SympyMod):
+            # Treat Mod as a binary operator of multiplication precedence.
+            p = PRECEDENCE["Mul"]
+            if (p < level) or ((not strict) and (p <= level)):
+                return "(%s)" % self._print(item)
+            else:
+                return self._print(item)
+
+        return super().parenthesize(item, level, strict=strict)
+
     def _print_Mod(self, expr):
         PREC = precedence(expr)
         return ('{} % {}'.format(*map(lambda x: self.parenthesize(x, PREC), expr.args)))

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -52,6 +52,11 @@ def test_PythonCodePrinter():
     assert prntr.doprint(p[0, 1]) == 'p[0, 1]'
     assert prntr.doprint(KroneckerDelta(x,y)) == '(1 if x == y else 0)'
 
+    # Ensure Mod prints with correct precedence when combined with Mul/unary minus
+    a = symbols('a')
+    assert prntr.doprint(a*Mod(x, y)) == 'a*(x % y)'
+    assert prntr.doprint(-Mod(x, y)) == '-(x % y)'
+
 
 def test_PythonCodePrinter_standard():
     import sys

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -277,6 +277,18 @@ def test_exponentiation():
     assert f(2.5) == 6.25
 
 
+def test_Mod_with_python_modules_precedence():
+    # Regression test for Mod precedence in pure Python lambdify (modules=[])
+    from sympy import Mod
+    a = symbols('a')
+    f = lambdify((a, x, y), a*Mod(x, y), modules=[])
+    # If precedence is wrong, this would compute (a*x) % y
+    assert f(2, 3, 7) == 6
+    # Also check that negation doesn't get pushed inside Mod
+    g = lambdify((x, y), -Mod(x, y), modules=[])
+    assert g(3, 7) == -3
+
+
 def test_sqrt():
     f = lambdify(x, sqrt(x))
     assert f(0) == 0.0


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
