### PR TITLE
bug fixed in F48-1B

### DIFF
--- a/sympy/assumptions/sathandlers.py
+++ b/sympy/assumptions/sathandlers.py
@@ -1,6 +1,10 @@
 from __future__ import print_function, division
 
-from collections import MutableMapping, defaultdict
+from collections import defaultdict
+try:
+    from collections.abc import MutableMapping
+except ImportError:  # pragma: no cover
+    from collections import MutableMapping
 
 from sympy.core import (Add, Mul, Pow, Integer, Number, NumberSymbol,)
 from sympy.core.numbers import ImaginaryUnit

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1,6 +1,10 @@
 """Base class for all the objects in SymPy"""
 from __future__ import print_function, division
-from collections import Mapping, defaultdict
+from collections import defaultdict
+try:
+    from collections.abc import Mapping
+except ImportError:  # pragma: no cover
+    from collections import Mapping
 from itertools import chain
 
 from .assumptions import BasicMeta, ManagedProperties

--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -14,6 +14,10 @@ from sympy.core.sympify import sympify, converter
 from sympy.utilities.iterables import iterable
 
 import collections
+try:
+    from collections.abc import MutableSet
+except ImportError:  # pragma: no cover
+    from collections import MutableSet
 
 
 class Tuple(Basic):
@@ -268,7 +272,7 @@ class Dict(Basic):
         return tuple(sorted(self.args, key=default_sort_key))
 
 
-class OrderedSet(collections.MutableSet):
+class OrderedSet(MutableSet):
     def __init__(self, iterable=None):
         if iterable:
             self.map = collections.OrderedDict((item, None) for item in iterable)

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -9,7 +9,11 @@ from .cache import cacheit
 from .compatibility import reduce, as_int, default_sort_key, range
 from mpmath.libmp import mpf_log, prec_to_dps
 
-from collections import defaultdict, Iterable
+from collections import defaultdict
+try:
+    from collections.abc import Iterable
+except ImportError:  # pragma: no cover
+    from collections import Iterable
 
 class Expr(Basic, EvalfMixin):
     """

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -25,7 +25,10 @@ every time you call ``show()`` and the old one is left to the garbage collector.
 from __future__ import print_function, division
 
 import inspect
-from collections import Callable
+try:
+    from collections.abc import Callable
+except ImportError:  # pragma: no cover
+    from collections import Callable
 import warnings
 import sys
 

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -86,7 +86,7 @@ class StrPrinter(Printer):
         return self.stringify(expr.args, " | ", PRECEDENCE["BitwiseOr"])
 
     def _print_AppliedPredicate(self, expr):
-        return '%s(%s)' % (expr.func, expr.arg)
+        return '%s(%s)' % (self._print(expr.func), self._print(expr.arg))
 
     def _print_Basic(self, expr):
         l = [self._print(o) for o in expr.args]
@@ -141,7 +141,7 @@ class StrPrinter(Printer):
         return 'E'
 
     def _print_ExprCondPair(self, expr):
-        return '(%s, %s)' % (expr.expr, expr.cond)
+        return '(%s, %s)' % (self._print(expr.expr), self._print(expr.cond))
 
     def _print_FiniteSet(self, s):
         s = sorted(s, key=default_sort_key)
@@ -193,7 +193,7 @@ class StrPrinter(Printer):
             m = '.Lopen'
         else:
             m = '.Ropen'
-        return fin.format(**{'a': a, 'b': b, 'm': m})
+        return fin.format(**{'a': self._print(a), 'b': self._print(b), 'm': m})
 
     def _print_AccumulationBounds(self, i):
         return "AccumBounds(%s, %s)" % (self._print(i.min), self._print(i.max))
@@ -204,10 +204,10 @@ class StrPrinter(Printer):
     def _print_Lambda(self, obj):
         args, expr = obj.args
         if len(args) == 1:
-            return "Lambda(%s, %s)" % (args.args[0], expr)
+            return "Lambda(%s, %s)" % (self._print(args.args[0]), self._print(expr))
         else:
             arg_string = ", ".join(self._print(arg) for arg in args)
-            return "Lambda((%s), %s)" % (arg_string, expr)
+            return "Lambda((%s), %s)" % (arg_string, self._print(expr))
 
     def _print_LatticeOp(self, expr):
         args = sorted(expr.args, key=default_sort_key)
@@ -216,9 +216,9 @@ class StrPrinter(Printer):
     def _print_Limit(self, expr):
         e, z, z0, dir = expr.args
         if str(dir) == "+":
-            return "Limit(%s, %s, %s)" % (e, z, z0)
+            return "Limit(%s, %s, %s)" % (self._print(e), self._print(z), self._print(z0))
         else:
-            return "Limit(%s, %s, %s, dir='%s')" % (e, z, z0, dir)
+            return "Limit(%s, %s, %s, dir='%s')" % (self._print(e), self._print(z), self._print(z0), dir)
 
     def _print_list(self, expr):
         return "[%s]" % self.stringify(expr, ", ")
@@ -341,7 +341,7 @@ class StrPrinter(Printer):
         return '-oo'
 
     def _print_Normal(self, expr):
-        return "Normal(%s, %s)" % (expr.mu, expr.sigma)
+        return "Normal(%s, %s)" % (self._print(expr.mu), self._print(expr.sigma))
 
     def _print_Order(self, expr):
         if all(p is S.Zero for p in expr.point) or not len(expr.variables):
@@ -630,7 +630,8 @@ class StrPrinter(Printer):
         }
 
         if expr.rel_op in charmap:
-            return '%s(%s, %s)' % (charmap[expr.rel_op], expr.lhs, expr.rhs)
+            # Print both sides using the printer so settings are respected
+            return '%s(%s, %s)' % (charmap[expr.rel_op], self._print(expr.lhs), self._print(expr.rhs))
 
         return '%s %s %s' % (self.parenthesize(expr.lhs, precedence(expr)),
                            self._relationals.get(expr.rel_op) or expr.rel_op,
@@ -722,7 +723,7 @@ class StrPrinter(Printer):
         return "%s.T" % self.parenthesize(T.arg, PRECEDENCE["Pow"])
 
     def _print_Uniform(self, expr):
-        return "Uniform(%s, %s)" % (expr.a, expr.b)
+        return "Uniform(%s, %s)" % (self._print(expr.a), self._print(expr.b))
 
     def _print_Union(self, expr):
         return 'Union(%s)' %(', '.join([self._print(a) for a in expr.args]))
@@ -777,11 +778,11 @@ class StrPrinter(Printer):
         return 'Object("%s")' % object.name
 
     def _print_IdentityMorphism(self, morphism):
-        return 'IdentityMorphism(%s)' % morphism.domain
+        return 'IdentityMorphism(%s)' % self._print(morphism.domain)
 
     def _print_NamedMorphism(self, morphism):
         return 'NamedMorphism(%s, %s, "%s")' % \
-               (morphism.domain, morphism.codomain, morphism.name)
+               (self._print(morphism.domain), self._print(morphism.codomain), morphism.name)
 
     def _print_Category(self, category):
         return 'Category("%s")' % category.name


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
